### PR TITLE
Add data params and result for change package implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The following providers are currently implemented:
 | create() | [_CreateParams_](src/Data/CreateParams.php) | [_CreateResult_](src/Data/CreateResult.php) | Creates an account and returns the `username` which can be used to identify the account in subsequent requests, plus other account information |
 | suspend() | [_AccountIdentifierParams_](src/Data/AccountIdentifierParams.php) | [_EmptyResult_](src/Data/EmptyResult.php) | Suspend an account |
 | unsuspend() | [_AccountIdentifierParams_](src/Data/AccountIdentifierParams.php) | [_EmptyResult_](src/Data/EmptyResult.php) | Unsuspend an account |
-| changePackage() | [_AccountIdentifierParams_](src/Data/AccountIdentifierParams.php) | [_EmptyResult_](src/Data/EmptyResult.php) | Change the package of an account |
+| changePackage() | [_ChangePackageParams_](src/Data/ChangePackageParams.php) | [_ChangePackageResult_](src/Data/ChangePackageResult.php) | Change the package of an account |
 | renew() | [_AccountIdentifierParams_](src/Data/AccountIdentifierParams.php) | [_EmptyResult_](src/Data/EmptyResult.php) | Renew an account's service |
 | terminate() | [_AccountIdentifierParams_](src/Data/AccountIdentifierParams.php) | [_EmptyResult_](src/Data/EmptyResult.php) | Permanently delete an account |
 

--- a/src/Category.php
+++ b/src/Category.php
@@ -7,6 +7,8 @@ namespace Upmind\ProvisionProviders\AutoLogin;
 use Upmind\ProvisionBase\Provider\BaseCategory;
 use Upmind\ProvisionBase\Provider\DataSet\AboutData;
 use Upmind\ProvisionProviders\AutoLogin\Data\AccountIdentifierParams;
+use Upmind\ProvisionProviders\AutoLogin\Data\ChangePackageParams;
+use Upmind\ProvisionProviders\AutoLogin\Data\ChangePackageResult;
 use Upmind\ProvisionProviders\AutoLogin\Data\CreateParams;
 use Upmind\ProvisionProviders\AutoLogin\Data\CreateResult;
 use Upmind\ProvisionProviders\AutoLogin\Data\EmptyResult;
@@ -51,7 +53,7 @@ abstract class Category extends BaseCategory
     /**
      * Change the package of an account.
      */
-    abstract public function changePackage(AccountIdentifierParams $params): EmptyResult;
+    abstract public function changePackage(ChangePackageParams $params): ChangePackageResult;
 
     /**
      * Renew an account's service.

--- a/src/Data/ChangePackageParams.php
+++ b/src/Data/ChangePackageParams.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Upmind\ProvisionProviders\AutoLogin\Data;
+
+use Upmind\ProvisionBase\Provider\DataSet\DataSet;
+use Upmind\ProvisionBase\Provider\DataSet\Rules;
+
+/**
+ * @property-read mixed $username Username or other unique service identifier
+ * @property-read string|null $service_identifier Secondary service identifier to use, if known up-front
+ * @property-read string|null $package_identifier Service package identifier, if any
+ * @property-read mixed[]|null $extra Any extra data to pass to the service endpoint
+ */
+class ChangePackageParams extends DataSet
+{
+    public static function rules(): Rules
+    {
+        return new Rules([
+            'username' => ['required'],
+            'service_identifier' => ['nullable', 'string'],
+            'package_identifier' => ['nullable', 'string'],
+            'extra' => ['nullable', 'array'],
+        ]);
+    }
+}

--- a/src/Data/ChangePackageResult.php
+++ b/src/Data/ChangePackageResult.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Upmind\ProvisionProviders\AutoLogin\Data;
+
+use Upmind\ProvisionBase\Provider\DataSet\ResultData;
+use Upmind\ProvisionBase\Provider\DataSet\Rules;
+
+/**
+ * @property-read mixed $username Username or other unique service identifier
+ * @property-read string|null $service_identifier Secondary service identifier, if any
+ * @property-read string|null $package_identifier Package identifier, if any
+ * @property-read array|null $extra Extra data, if any
+ */
+class ChangePackageResult extends ResultData
+{
+    public static function rules(): Rules
+    {
+        return new Rules([
+		'username' => ['filled'],
+		'service_identifier' => ['nullable', 'string'],
+		'package_identifier' => ['nullable', 'string'],
+		'extra' => ['nullable', 'array'],
+        ]);
+    }
+
+    /**
+     * Set the result username.
+     */
+    public function setUsername(string $username): self
+    {
+        $this->setValue('username', $username);
+        return $this;
+    }
+
+    /**
+     * Set the result secondary service identifier.
+     */
+    public function setServiceIdentifier(?string $serviceIdentifier): self
+    {
+        $this->setValue('service_identifier', $serviceIdentifier);
+        return $this;
+    }
+
+    /**
+     * Set the result package identifier.
+     */
+    public function setPackageIdentifier(?string $packageIdentifier): self
+    {
+        $this->setValue('package_identifier', $packageIdentifier);
+        return $this;
+    }
+
+    /**
+     * Set the result extra data.
+     */
+    public function setExtra(?array $extra): self
+    {
+        $this->setValue('extra', $extra);
+        return $this;
+    }
+}

--- a/src/Providers/Example/Provider.php
+++ b/src/Providers/Example/Provider.php
@@ -9,6 +9,8 @@ use Upmind\ProvisionBase\Provider\Contract\ProviderInterface;
 use Upmind\ProvisionBase\Provider\DataSet\AboutData;
 use Upmind\ProvisionProviders\AutoLogin\Category;
 use Upmind\ProvisionProviders\AutoLogin\Data\AccountIdentifierParams;
+use Upmind\ProvisionProviders\AutoLogin\Data\ChangePackageParams;
+use Upmind\ProvisionProviders\AutoLogin\Data\ChangePackageResult;
 use Upmind\ProvisionProviders\AutoLogin\Data\CreateParams;
 use Upmind\ProvisionProviders\AutoLogin\Data\CreateResult;
 use Upmind\ProvisionProviders\AutoLogin\Data\EmptyResult;
@@ -81,11 +83,12 @@ class Provider extends Category implements ProviderInterface
 
     /**
      * @inheritDoc
+     *
+     * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
      */
-    public function changePackage(AccountIdentifierParams $params): EmptyResult
+    public function changePackage(ChangePackageParams $params): ChangePackageResult
     {
-        return EmptyResult::create()
-            ->setMessage('Account unsuspended');
+        $this->errorResult('Not Implemented');
     }
 
     /**

--- a/src/Providers/Generic/Data/Configuration.php
+++ b/src/Providers/Generic/Data/Configuration.php
@@ -11,24 +11,24 @@ use Upmind\ProvisionBase\Provider\DataSet\Rules;
  * @property-read string|null $access_token Access bearer token to send in requests
  * @property-read string $login_endpoint_url Endpoint which generates login URLs
  * @property-read string|null $login_endpoint_http_method HTTP method to use for the login endpoint
- * @property-read boolean $has_create Whether or not this configuration has a create endpoint
+ * @property-read boolean|null $has_create Whether or not this configuration has a create endpoint
  * @property-read string|null $create_endpoint_url Endpoint which creates a service account and returns a username
  * @property-read string|null $create_endpoint_http_method HTTP method to use for the create endpoint
- * @property-read boolean $has_suspend Whether or not this configuration has suspend + unsuspend endpoints
+ * @property-read boolean|null $has_suspend Whether or not this configuration has suspend + unsuspend endpoints
  * @property-read string|null $suspend_endpoint_url Endpoint which suspends a service account
  * @property-read string|null $suspend_endpoint_http_method HTTP method to use for the suspend endpoint
  * @property-read string|null $unsuspend_endpoint_url Endpoint which unsuspends a service account
  * @property-read string|null $unsuspend_endpoint_http_method HTTP method to use for the unsuspend endpoint
- * @property-read boolean $has_change_package Whether or not this configuration has a change package endpoint
+ * @property-read boolean|null $has_change_package Whether or not this configuration has a change package endpoint
  * @property-read string|null $change_package_endpoint_url Endpoint which changes the package of a service account
  * @property-read string|null $change_package_endpoint_http_method HTTP method to use for the change package endpoint
- * @property-read boolean $has_renew Whether or not this configuration has a renew endpoint
+ * @property-read boolean|null $has_renew Whether or not this configuration has a renew endpoint
  * @property-read string|null $renew_endpoint_url Endpoint which renews a service account
  * @property-read string|null $renew_endpoint_http_method HTTP method to use for the renew endpoint
- * @property-read boolean $has_terminate Whether or not this configuration has a terminate endpoint
+ * @property-read boolean|null $has_terminate Whether or not this configuration has a terminate endpoint
  * @property-read string|null $terminate_endpoint_url Endpoint which terminates a service account
  * @property-read string|null $terminate_endpoint_http_method HTTP method to use for the terminate endpoint
- * @property-read boolean $skip_ssl_verification Whether or not to allow invalid SSL certificates
+ * @property-read boolean|null $skip_ssl_verification Whether or not to allow invalid SSL certificates
  * @property-read string|null $extra_data_1 Extra data field 1
  * @property-read string|null $extra_data_2 Extra data field 2
  * @property-read string|null $extra_data_3 Extra data field 3

--- a/src/Providers/Generic/Provider.php
+++ b/src/Providers/Generic/Provider.php
@@ -11,6 +11,8 @@ use Upmind\ProvisionBase\Provider\Contract\ProviderInterface;
 use Upmind\ProvisionBase\Provider\DataSet\AboutData;
 use Upmind\ProvisionProviders\AutoLogin\Category;
 use Upmind\ProvisionProviders\AutoLogin\Data\AccountIdentifierParams;
+use Upmind\ProvisionProviders\AutoLogin\Data\ChangePackageParams;
+use Upmind\ProvisionProviders\AutoLogin\Data\ChangePackageResult;
 use Upmind\ProvisionProviders\AutoLogin\Data\CreateParams;
 use Upmind\ProvisionProviders\AutoLogin\Data\CreateResult;
 use Upmind\ProvisionProviders\AutoLogin\Data\EmptyResult;
@@ -188,7 +190,7 @@ class Provider extends Category implements ProviderInterface
      * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
      * @throws \Upmind\ProvisionProviders\AutoLogin\Exceptions\OperationFailed
      */
-    public function changePackage(AccountIdentifierParams $params): EmptyResult
+    public function changePackage(ChangePackageParams $params): ChangePackageResult
     {
         if (!$this->configuration->has_change_package) {
             $this->errorResult('No changePackage endpoint set in this configuration');
@@ -215,7 +217,11 @@ class Provider extends Category implements ProviderInterface
         $handler = new OperationResponseHandler($response);
         $handler->assertOperationSuccess('change package');
 
-        return EmptyResult::create()->setMessage('Account package changed');
+        return ChangePackageResult::create()
+            ->setUsername($params->username)
+            ->setServiceIdentifier($params->service_identifier)
+            ->setPackageIdentifier($params->package_identifier)
+            ->setMessage('Account package changed');
     }
 
     /**

--- a/src/Providers/SpamExperts/Provider.php
+++ b/src/Providers/SpamExperts/Provider.php
@@ -11,6 +11,8 @@ use Upmind\ProvisionBase\Provider\Contract\ProviderInterface;
 use Upmind\ProvisionBase\Provider\DataSet\AboutData;
 use Upmind\ProvisionProviders\AutoLogin\Category;
 use Upmind\ProvisionProviders\AutoLogin\Data\AccountIdentifierParams;
+use Upmind\ProvisionProviders\AutoLogin\Data\ChangePackageParams;
+use Upmind\ProvisionProviders\AutoLogin\Data\ChangePackageResult;
 use Upmind\ProvisionProviders\AutoLogin\Data\CreateParams;
 use Upmind\ProvisionProviders\AutoLogin\Data\CreateResult;
 use Upmind\ProvisionProviders\AutoLogin\Data\EmptyResult;
@@ -100,7 +102,7 @@ class Provider extends Category implements ProviderInterface
     /**
      * @throws \Upmind\ProvisionBase\Exception\ProvisionFunctionError
      */
-    public function changePackage(AccountIdentifierParams $params): EmptyResult
+    public function changePackage(ChangePackageParams $params): ChangePackageResult
     {
         $this->errorResult('Operation not supported');
     }


### PR DESCRIPTION
### Description
In order to conform with the other `changePackage()` implementations in other provision provider types, we need to create `ChangePackageParams` and `ChangePackageResult`. This will allow a target package to be specified when changing packages.

### Changes
- Creates the `ChangePackageParams` and `ChangePackageResult` data objects
- Updates the parameter type of the `changePackage()` provider method to use a `ChangePackageParams` object
- Updates the method return type of the `changePackage()` provider method to return a `ChangePackageResult` object
- Updates the `changePackage()` method in the Example, Generic, and SpamExperts providers to use the new objects
- Updates the README with the new object types used by the `changePackage()` method